### PR TITLE
fix: broken docs reference links update

### DIFF
--- a/Tutorials/Boston Housing - XGBoost (Batch Transform) - High Level.ipynb
+++ b/Tutorials/Boston Housing - XGBoost (Batch Transform) - High Level.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "As an introduction to using SageMaker's High Level Python API we will look at a relatively simple problem. Namely, we will use the [Boston Housing Dataset](https://www.cs.toronto.edu/~delve/data/boston/bostonDetail.html) to predict the median value of a home in the area of Boston Mass.\n",
     "\n",
-    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/latest/)\n",
+    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/stable/)\n",
     "\n",
     "## General Outline\n",
     "\n",

--- a/Tutorials/Boston Housing - XGBoost (Deploy) - High Level.ipynb
+++ b/Tutorials/Boston Housing - XGBoost (Deploy) - High Level.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "As an introduction to using SageMaker's High Level Python API we will look at a relatively simple problem. Namely, we will use the [Boston Housing Dataset](https://www.cs.toronto.edu/~delve/data/boston/bostonDetail.html) to predict the median value of a home in the area of Boston Mass.\n",
     "\n",
-    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/latest/)\n",
+    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/stable/)\n",
     "\n",
     "## General Outline\n",
     "\n",

--- a/Tutorials/Boston Housing - XGBoost (Hyperparameter Tuning) - High Level.ipynb
+++ b/Tutorials/Boston Housing - XGBoost (Hyperparameter Tuning) - High Level.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "As an introduction to using SageMaker's High Level Python API for hyperparameter tuning, we will look again at the [Boston Housing Dataset](https://www.cs.toronto.edu/~delve/data/boston/bostonDetail.html) to predict the median value of a home in the area of Boston Mass.\n",
     "\n",
-    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/latest/)\n",
+    "The documentation for the high level API can be found on the [ReadTheDocs page](http://sagemaker.readthedocs.io/en/stable/)\n",
     "\n",
     "## General Outline\n",
     "\n",


### PR DESCRIPTION
It seems docs transfer https://sagemaker.readthedocs.io/en/latest/ to
https://sagemaker.readthedocs.io/en/stable/