### PR TITLE
fix: correct sagemaker methods over deprecated ones after Sagemaker SDK V2 update

### DIFF
--- a/Tutorials/Boston Housing - XGBoost (Batch Transform) - High Level.ipynb
+++ b/Tutorials/Boston Housing - XGBoost (Batch Transform) - High Level.ipynb
@@ -74,7 +74,8 @@
    "source": [
     "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
-    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker import image_uris\n",
+    "# from sagemaker.amazon.amazon_estimator import get_image_uri - deprecated on Sagemaker SDK v2\n",
     "from sagemaker.predictor import csv_serializer\n",
     "\n",
     "# This is an object that represents the SageMaker session that we are currently operating in. This\n",
@@ -216,13 +217,13 @@
    "outputs": [],
    "source": [
     "# As stated above, we use this utility method to construct the image name for the training container.\n",
-    "container = get_image_uri(session.boto_region_name, 'xgboost')\n",
+    "container = image_uris.retrieve('xgboost', session.boto_region_name, version='latest')\n",
     "\n",
     "# Now that we know which container to use, we can construct the estimator object.\n",
     "xgb = sagemaker.estimator.Estimator(container, # The image name of the training container\n",
     "                                    role,      # The IAM role to use (our current role in this case)\n",
-    "                                    train_instance_count=1, # The number of instances to use for training\n",
-    "                                    train_instance_type='ml.m4.xlarge', # The type of instance to use for training\n",
+    "                                    instance_count=1, # The number of instances to use for training\n",
+    "                                    instance_type='ml.m4.xlarge', # The type of instance to use for training\n",
     "                                    output_path='s3://{}/{}/output'.format(session.default_bucket(), prefix),\n",
     "                                                                        # Where to save the output (the model artifacts)\n",
     "                                    sagemaker_session=session) # The current SageMaker session"
@@ -393,9 +394,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_pytorch_p36",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_pytorch_p36"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -407,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
[Sagemaker SDK V2](https://sagemaker.readthedocs.io/en/stable/v2.html) had made several changes and made the notebook named `Tutorials/Boston Housing - XGBoost (Batch Transform) - High Level.ipynb ` went on an error when trying to get the xgboost container image. I have made adjustments on the proper code lines.
