### PR TITLE
Fix issues on import joblib and pd.concat

### DIFF
--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Batch Transform) - Solution.ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Batch Transform) - Solution.ipynb
@@ -274,7 +274,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",
@@ -407,8 +407,8 @@
     "#       Make sure that the files you create are in the correct format.\n",
     "\n",
     "# Solution:\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {

--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Batch Transform).ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Batch Transform).ipynb
@@ -274,7 +274,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",

--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Hyperparameter Tuning) - Solution.ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Hyperparameter Tuning) - Solution.ipynb
@@ -274,7 +274,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",
@@ -396,11 +396,11 @@
     "# Solution:\n",
     "# The test data shouldn't contain the ground truth labels as they are what the model is\n",
     "# trying to predict. We will end up using them afterward to compare the predictions to.\n",
-    "# pd.concat([test_y, test_X], axis=1).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
+    "# pd.concat([pd.DataFrame(test_y), pd.DataFrame(test_X)], axis=1).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
     "pd.DataFrame(test_X).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
     "\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {

--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Hyperparameter Tuning).ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Hyperparameter Tuning).ipynb
@@ -274,7 +274,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",
@@ -393,9 +393,9 @@
     "# First, save the test data to test.csv in the data_dir directory. Note that we do not save the associated ground truth\n",
     "# labels, instead we will use them later to compare with our model output.\n",
     "\n",
-    "pd.concat([test_y, test_X], axis=1).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(test_y), pd.DataFrame(test_X)], axis=1).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {

--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Updating a Model) - Solution.ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Updating a Model) - Solution.ipynb
@@ -285,7 +285,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",
@@ -411,8 +411,8 @@
    "source": [
     "pd.DataFrame(test_X).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
     "\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {

--- a/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Updating a Model).ipynb
+++ b/Mini-Projects/IMDB Sentiment Analysis - XGBoost (Updating a Model).ipynb
@@ -285,7 +285,7 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "# joblib is an enhanced version of pickle that is more efficient for storing NumPy arrays\n",
     "\n",
     "def extract_BoW_features(words_train, words_test, vocabulary_size=5000,\n",
@@ -411,8 +411,8 @@
    "source": [
     "pd.DataFrame(test_X).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
     "\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {

--- a/Tutorials/IMDB Sentiment Analysis - XGBoost - Web App.ipynb
+++ b/Tutorials/IMDB Sentiment Analysis - XGBoost - Web App.ipynb
@@ -274,7 +274,7 @@
     "from sklearn.feature_extraction.text import CountVectorizer\n",
     "\n",
     "# sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. \n",
-    "# from sklearn.externals import joblib\n",
+    "# import joblib\n",
     "\n",
     "# Import joblib package directly\n",
     "import joblib\n",
@@ -402,8 +402,8 @@
    "source": [
     "pd.DataFrame(test_X).to_csv(os.path.join(data_dir, 'test.csv'), header=False, index=False)\n",
     "\n",
-    "pd.concat([val_y, val_X], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
-    "pd.concat([train_y, train_X], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
+    "pd.concat([pd.DataFrame(val_y), pd.DataFrame(val_X)], axis=1).to_csv(os.path.join(data_dir, 'validation.csv'), header=False, index=False)\n",
+    "pd.concat([pd.DataFrame(train_y), pd.DataFrame(train_X)], axis=1).to_csv(os.path.join(data_dir, 'train.csv'), header=False, index=False)"
    ]
   },
   {


### PR DESCRIPTION
Dear Udacity team,
I'm working through the Machine Learning Engineering Nanodegree course and found a couple of bugs to be fixed while working on the first mini-project IMDB Sentiment Analysis - XGBoost (Batch Transform).ipynb.
- Issue #16 
- pd.concat method would not work as it is done now with lists and Numpy arrays inputs, because it requires Pandas objects as input

Please have a look at it, let me know if it makes sense and if there is anything else where I can help, and let's fix the issues so the students are not disrupted by them.
Thank you
Jaime