### PR TITLE
Revert training instance to `ml.p2.xlarge`

### DIFF
--- a/Project/SageMaker Project.ipynb
+++ b/Project/SageMaker Project.ipynb
@@ -721,7 +721,7 @@
     "                    role=role,\n",
     "                    framework_version='0.4.0',\n",
     "                    train_instance_count=1,\n",
-    "                    train_instance_type='ml.g4dn.xlarge',\n",
+    "                    train_instance_type='ml.p2.xlarge',\n",
     "                    hyperparameters={\n",
     "                        'epochs': 10,\n",
     "                        'hidden_dim': 200,\n",


### PR DESCRIPTION
ml.g4dn.xlarge instance is not available in integrated AWS workspace. This change breaks code for all students who use the integrated workspaces. Reverted to p2.xlarge to avoid issues.